### PR TITLE
Fix last location showing up when creating a new character

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -112,6 +112,7 @@
                                 viewmodel.selectedValue = {type: "", index: -1}
 
                                 viewmodel.positions.appartment = data.locations
+                                viewmodel.newChar = data.isNew
                                 break;
                         }
                     })


### PR DESCRIPTION
**Describe Pull request**
Fixes a bug where you could select `Last Location` when choosing an apartment for a new character.

Fixes qbcore-framework/qb-multicharacter#149
Fixes #47

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? **yes**
- Does your code fit the style guidelines? **yes**
- Does your PR fit the contribution guidelines? **yes**
