### PR TITLE
FIX: Detects if the player is inside/owns the house

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -165,6 +165,7 @@ RegisterNUICallback('spawnplayer', function(data, cb)
     local insideMeta = PlayerData.metadata["inside"]
     if type == "current" then
         PreSpawnPlayer()
+            
         QBCore.Functions.GetPlayerData(function(pd)
             ped = PlayerPedId()
             SetEntityCoords(ped, pd.position.x, pd.position.y, pd.position.z)
@@ -185,7 +186,14 @@ RegisterNUICallback('spawnplayer', function(data, cb)
         PostSpawnPlayer()
     elseif type == "house" then
         PreSpawnPlayer()
-            
+        
+        QBCore.Functions.GetPlayerData(function(pd)
+            ped = PlayerPedId()
+            SetEntityCoords(ped, pd.position.x, pd.position.y, pd.position.z)
+            SetEntityHeading(ped, pd.position.a)
+            FreezeEntityPosition(ped, false)
+        end)
+         
         if insideMeta.house ~= nil then
         local houseId = insideMeta.house
         TriggerEvent('qb-houses:client:LastLocationHouse', houseId)

--- a/client.lua
+++ b/client.lua
@@ -185,6 +185,12 @@ RegisterNUICallback('spawnplayer', function(data, cb)
         PostSpawnPlayer()
     elseif type == "house" then
         PreSpawnPlayer()
+            
+        if insideMeta.house ~= nil then
+        local houseId = insideMeta.house
+        TriggerEvent('qb-houses:client:LastLocationHouse', houseId)
+        end
+        
         TriggerEvent('qb-houses:client:enterOwnedHouse', location)
         TriggerServerEvent('QBCore:Server:OnPlayerLoaded')
         TriggerEvent('QBCore:Client:OnPlayerLoaded')


### PR DESCRIPTION

If the player buys a house, and then selects it in qb-spawn in another login, he has to leave and enter the house to determine that it is his house.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? For sure!
- Does your code fit the style guidelines? Yes
- Does your PR fit the contribution guidelines? Yes
