### PR TITLE
 [FIX] Determine if player owns house after spawn

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -192,6 +192,17 @@ RegisterNUICallback('spawnplayer', function(data, cb)
         PostSpawnPlayer()
     elseif type == "house" then
         PreSpawnPlayer()
+        QBCore.Functions.GetPlayerData(function(pd)
+            ped = PlayerPedId()
+            SetEntityCoords(ped, Houses[location].coords.enter.x, Houses[location].coords.enter.y, Houses[location].coords.enter.z)
+            SetEntityHeading(ped, pd.position.a)
+            FreezeEntityPosition(ped, false)
+        end)
+        if insideMeta.house ~= nil then
+            local houseId = insideMeta.house
+            TriggerEvent('qb-houses:client:LastLocationHouse', houseId)
+        end
+         
         TriggerEvent('qb-houses:client:enterOwnedHouse', location)
         TriggerServerEvent('QBCore:Server:OnPlayerLoaded')
         TriggerEvent('QBCore:Client:OnPlayerLoaded')


### PR DESCRIPTION
**Describe Pull request**
Hello, first of all I would like to say if not if this form is the most stabilized so that the player can in fact determine that he is the owner of the house after he spawns with the qb-spawn.

I noticed that when you used the last-location to teleport inside the house it worked and apparently when you choose the house, you need to enter and leave it in order to actually use it. I think it's a bit annoying for the player.

What I did was stabilize the ped in front of the house door before entering.


If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] (Be honest)
- Does your code fit the style guidelines? [yes/no]
- Does your PR fit the contribution guidelines? [yes/no]
