### PR TITLE
Fix: Player spawns properly

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -172,24 +172,25 @@ RegisterNUICallback('spawnplayer', function(data, cb)
     local insideMeta = PlayerData.metadata['inside']
     if type == 'current' then
         PreSpawnPlayer()
+    
         QBCore.Functions.GetPlayerData(function(pd)
             ped = PlayerPedId()
             SetEntityCoords(ped, pd.position.x, pd.position.y, pd.position.z)
             SetEntityHeading(ped, pd.position.a)
             FreezeEntityPosition(ped, false)
-        end)
-
-        if insideMeta.house ~= nil then
-            local houseId = insideMeta.house
-            TriggerEvent('qb-houses:client:LastLocationHouse', houseId)
-        elseif insideMeta.apartment.apartmentType ~= nil or insideMeta.apartment.apartmentId ~= nil then
-            local apartmentType = insideMeta.apartment.apartmentType
-            local apartmentId = insideMeta.apartment.apartmentId
-            TriggerEvent('qb-apartments:client:LastLocationHouse', apartmentType, apartmentId)
-        end
-        TriggerServerEvent('QBCore:Server:OnPlayerLoaded')
-        TriggerEvent('QBCore:Client:OnPlayerLoaded')
-        PostSpawnPlayer()
+    
+            local insideMeta = pd.metadata and pd.metadata['inside'] or {}
+    
+            if insideMeta.house then
+                TriggerEvent('qb-houses:client:LastLocationHouse', insideMeta.house)
+            elseif insideMeta.apartment and insideMeta.apartment.apartmentType and insideMeta.apartment.apartmentId then
+                TriggerEvent('qb-apartments:client:LastLocationHouse', insideMeta.apartment.apartmentType, insideMeta.apartment.apartmentId)
+            end
+    
+            TriggerServerEvent('QBCore:Server:OnPlayerLoaded')
+            TriggerEvent('QBCore:Client:OnPlayerLoaded')
+            PostSpawnPlayer()
+        end)    
     elseif type == 'house' then
         PreSpawnPlayer()
         TriggerEvent('qb-houses:client:enterOwnedHouse', location)

--- a/locales/ua.lua
+++ b/locales/ua.lua
@@ -1,0 +1,12 @@
+local Translations = {
+    ui = {
+        last_location = "Останнє місце",
+        confirm = "Підтвердити",
+        where_would_you_like_to_start = "Звідки ви бажаєте розпочати?",
+    }
+}
+
+Lang = Lang or Locale:new({
+    phrases = Translations,
+    warnOnMissing = true
+})


### PR DESCRIPTION
This PR resolves a bug where players were incorrectly spawning at the character preview location instead of their actual last known position.

Problem:
The original implementation called QBCore:Server:OnPlayerLoaded, QBCore:Client:OnPlayerLoaded, and PostSpawnPlayer() outside the asynchronous QBCore.Functions.GetPlayerData callback. As a result, the spawn sequence would proceed before the player's data (including coordinates) was fully loaded, leading to the player remaining at the default camera or preview location.

Solution:
The fix moves all spawn-related logic inside the GetPlayerData callback to ensure:

The player ped is fully created.

The correct position and heading are available before teleporting.

Housing or apartment metadata is handled after coordinate placement.

The spawn function is only triggered once all required data is ready.

Tested:
Verified correct spawning in last known position.

Verified teleportation to apartments and houses functions correctly.

No regression observed in normal or new character spawn types.